### PR TITLE
Add missing HEADER_SEARCH_PATHS for relase.

### DIFF
--- a/RCTRefreshControl.xcodeproj/project.pbxproj
+++ b/RCTRefreshControl.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Trying to archive a project using this component fails since it can't locate some React headers. This is due to missing header search path for release, development builds work fine. In this PR I added the missing search path.
