### PR TITLE
Fix #14. Build fails with react-native@0.10

### DIFF
--- a/RCTRefreshControl.m
+++ b/RCTRefreshControl.m
@@ -21,7 +21,7 @@ RCT_EXPORT_MODULE()
   return self.bridge.uiManager.methodQueue;
 }
 
-RCT_EXPORT_METHOD(configure:(NSNumber *)reactTag
+RCT_EXPORT_METHOD(configure:(nonnull NSNumber *)reactTag
                   options:(NSDictionary *)options
                   callback:(RCTResponseSenderBlock)callback) {
   [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(configure:(NSNumber *)reactTag
   }];
 }
 
-RCT_EXPORT_METHOD(beginRefreshing:(NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(beginRefreshing:(nonnull NSNumber *)reactTag) {
   [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
     
     UIView *view = viewRegistry[reactTag];
@@ -69,7 +69,7 @@ RCT_EXPORT_METHOD(beginRefreshing:(NSNumber *)reactTag) {
   }];
 }
 
-RCT_EXPORT_METHOD(endRefreshing:(NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(endRefreshing:(nonnull NSNumber *)reactTag) {
   [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
     
     UIView *view = viewRegistry[reactTag];


### PR DESCRIPTION
"Argument 0 (NSNumber) of RCTRefreshControl.configure has unspecified nullability but React requires that all NSNumber arguments are explicitly marked as `nonnull` to ensure compatibility with Android."
