### PR TITLE
Use @flow-weak to avoid errors in Flow 0.14

### DIFF
--- a/RCTRefreshControl.ios.js
+++ b/RCTRefreshControl.ios.js
@@ -1,6 +1,6 @@
 /**
  * @providesModule RCTRefreshControl
- * @flow
+ * @flow-weak
  */
 'use strict';
 

--- a/RCTRefreshControl.ios.js
+++ b/RCTRefreshControl.ios.js
@@ -1,6 +1,6 @@
 /**
  * @providesModule RCTRefreshControl
- * @flow-weak
+ * @flow weak
  */
 'use strict';
 


### PR DESCRIPTION
I'm attaching the errors below in case someone prefers to actually fix them instead. I didn't know what to do about the "Computed property cannot be assigned with possibly null/undefined value" ones, in particular.

```
RCTRefreshControl.ios.js:30:23,29: parameter configs
Missing annotation

RCTRefreshControl.ios.js:30:32,39: parameter callback
Missing annotation

RCTRefreshControl.ios.js:31:22,55: call of method findNodeHandle
Error:
RCTRefreshControl.ios.js:39:9,40: assignment of computed property/element
Computed property cannot be assigned with possibly null value
RCTRefreshControl.ios.js:31:22,55: null

RCTRefreshControl.ios.js:31:22,55: call of method findNodeHandle
Error:
RCTRefreshControl.ios.js:39:9,40: assignment of computed property/element
Computed property cannot be assigned with possibly undefined value
RCTRefreshControl.ios.js:31:22,55: undefined

RCTRefreshControl.ios.js:43:27,30: parameter node
Missing annotation

Found 5 errors
```
